### PR TITLE
Allow absolute paths

### DIFF
--- a/src/Asset.php
+++ b/src/Asset.php
@@ -34,6 +34,10 @@ final class Asset
      */
     public function getUrl($path): string
     {
-        return $this->packages->getUrl('/' . \ltrim($path, '/'));
+        /**
+         * Do not prefix absolute urls
+         * This aligns with symfony asset package behaviour
+         */
+        return $this->packages->getUrl($path);
     }
 }

--- a/tests/src/AssetExtensionTest.php
+++ b/tests/src/AssetExtensionTest.php
@@ -24,7 +24,14 @@ class AssetExtensionTest extends TestCase
         $stub = $this->createMock(Packages::class);
         $stub->method('getUrl')
             ->willReturnCallback(function ($path) {
-                return 'https://Ixocreate' . $path;
+                /**
+                 * Do not prefix absolute urls
+                 * This aligns with symfony asset package behaviour
+                 */
+                if (\mb_strpos($path, 'http') === 0) {
+                    return $path;
+                }
+                return 'https://ixocreate.test/' . \ltrim($path, '/');
             });
         $asset = new Asset($stub);
         $assetExtension = new AssetExtension($asset);
@@ -32,6 +39,9 @@ class AssetExtensionTest extends TestCase
         $this->assertInstanceOf(AssetExtension::class, $assetExtension);
 
         $this->assertSame('asset', $assetExtension->getName());
-        $this->assertSame('https://Ixocreate/Asset/', $assetExtension('Asset/'));
+        $this->assertSame('https://ixocreate.test/assets/', $assetExtension('assets/'));
+        $this->assertSame('https://ixocreate.test/assets/', $assetExtension('/assets/'));
+
+        $this->assertSame('https://ixocreate.test/assets/', $assetExtension('https://ixocreate.test/assets/'));
     }
 }

--- a/tests/src/AssetTest.php
+++ b/tests/src/AssetTest.php
@@ -22,18 +22,29 @@ class AssetTest extends TestCase
     {
         $stub = $this->createMock(Packages::class);
 
-
         $stub->method('getUrl')
             ->willReturnCallback(function ($path) {
-                return 'https://phpunit.de/manual/6.5' . $path;
+                /**
+                 * Do not prefix absolute urls
+                 * This aligns with symfony asset package behaviour
+                 */
+                if (\mb_strpos($path, 'http') === 0) {
+                    return $path;
+                }
+                return 'https://ixocreate.test/' . \ltrim($path, '/');
             });
 
 
         $asset = new Asset($stub);
 
-        $mitSlash = $asset->getUrl('/trsttstt');
-        $ohneSlash = $asset->getUrl('trsttstt');
-        $this->assertSame('https://phpunit.de/manual/6.5/trsttstt', $mitSlash);
-        $this->assertSame('https://phpunit.de/manual/6.5/trsttstt', $ohneSlash);
+        $this->assertSame('https://ixocreate.test/assets', $asset->getUrl('/assets'));
+
+        /**
+         * Asset::getUrl() does not automatically prefix paths
+         * This should be done in the asset url configuration
+         */
+        $this->assertSame('https://ixocreate.test/assets', $asset->getUrl('assets'));
+
+        $this->assertSame('https://ixocreate.test/assets', $asset->getUrl('https://ixocreate.test/assets'));
     }
 }


### PR DESCRIPTION
Do not prefix absolute URLs.
This aligns with Symfony Asset Package behaviour.
Allows to use absolute URLs for whitelabel images in admin config.